### PR TITLE
Updates that use the new supercollider OSC path

### DIFF
--- a/8-osc-tidal-supercollider.js
+++ b/8-osc-tidal-supercollider.js
@@ -30,7 +30,7 @@ parseTidal = (args) => {
 // address of the OSC message, defined in the file tidal-forward.sc
 // open the console to see the messages, using Ctrl+Alt+I (windows), Cmd+Opt+I (mac), or Ctrl + Shift + I(linux)
 //
-msg.on('/play2', (args) => {
+msg.on('/dirt/play', (args) => {
 // log osc results to console
  //log(args)
  tidal = parseTidal(args)
@@ -48,7 +48,7 @@ blend = 0
 // receive args from supercollider in hydra. Tidal sends OSC messages
 // ahead of the time the sound is plays, so it is necessary to use setTimeout
 // in order to wait to change the visuals
-msg.on('/play2', (args) => {
+msg.on('/dirt/play', (args) => {
   // parse the values from tidal
  var tidal = parseTidal(args)
 //
@@ -81,7 +81,7 @@ osc(20, 0.1, 0.8)
 freq = 10
 numSides = 0
 //
-msg.on('/play2', (args) => {
+msg.on('/dirt/play', (args) => {
   // parse the values from tidal
  var tidal = parseTidal(args)
 //

--- a/tidal/tidal-forward.scd
+++ b/tidal/tidal-forward.scd
@@ -2,11 +2,12 @@
 // This code forwards messages from tidal to an additional port via OSC.
 // From https://github.com/tado/ofxTidalCycles
 
-var addr = NetAddr.new("127.0.0.1", 3333);
-OSCFunc({ |msg, time, tidalAddr|
+var hydraAddr = NetAddr.new("127.0.0.1", 3333);
+var tidalAddr = NetAddr.new("127.0.0.1", 6010);
+OSCFunc.newMatching({ |msg, time, addr, port|
 	var latency = time - Main.elapsedTime;
 	msg = msg ++ ["time", time, "latency", latency];
 	msg.postln;
-	addr.sendBundle(latency, msg)
-}, '/play2').fix;
+	hydraAddr.sendBundle(latency, msg)
+}, '/dirt/play', tidalAddr);
 SuperDirt.start;


### PR DESCRIPTION
The previous examples didn't work for me, and I see a lot of people struggling with getting these examples working on various forums. I figured out a syntax that works with the SuperCollider syntax as of 3.11.2, and which only sends through SuperDirt sample OSC messages, which is a good place to start for not having too many messages I think.

Let me know what you think!